### PR TITLE
staging: iio: use monotonic time since boot for event timestamps

### DIFF
--- a/drivers/staging/iio/iio.h
+++ b/drivers/staging/iio/iio.h
@@ -181,14 +181,7 @@ int __iio_add_chan_devattr(const char *postfix,
  **/
 static inline s64 iio_get_time_ns(void)
 {
-	struct timespec ts;
-	/*
-	 * calls getnstimeofday.
-	 * If hrtimers then up to ns accurate, if not microsecond.
-	 */
-	ktime_get_real_ts(&ts);
-
-	return timespec_to_ns(&ts);
+	return ktime_to_ns(ktime_get_boottime());
 }
 
 /* Device operating modes */


### PR DESCRIPTION
Recent Android versions are expecting a monotonic timestamp that
includes the time since boot, not the time elapsed since boot while
the device was awake.

Change-Id: I68681be011162fe102287243f8e200b08d8c31e2