### PR TITLE
cpufreq: pegasusq: add support for setting a boost freq/cpulock

### DIFF
--- a/drivers/cpufreq/Kconfig
+++ b/drivers/cpufreq/Kconfig
@@ -266,6 +266,11 @@ config CPU_FREQ_GOV_ADAPTIVE
 config CPU_FREQ_GOV_PEGASUSQ
 	tristate "'pegasusq' cpufreq policy governor"
 
+config CPU_FREQ_GOV_PEGASUSQ_BOOST
+	bool "pegasusq - enable suport for userspace-controlled cpu boosts"
+	depends on CPU_FREQ_GOV_PEGASUSQ
+	default n
+
 config CPU_FREQ_GOV_SLP
 	tristate "'slp' cpufreq policy governor"
 


### PR DESCRIPTION
Currently, the pegasusq cpufreq driver has no way of allowing a
userspace component (such as a powerhal) to indicate that the cpu
should be brought to a higher clockspeed in anticipation of user input
(such as on POWER_HINT_INTERACTION).

This commit adds three interfaces to pegasusq, boost_freq and
boost_mincpus, and boost_lock_time. boost_freq sets the minimum
frequency for the cpus held online, and boost_mincpus specifies the
minimum number of cpus to hold online. boost_lock_time is measured
in nanoseconds, and is the amount of time to wait before restoring
normal control. boost_mincpus and boost_freq will not have an
effect until boost_lock_time != 0.

Reading from boost_lock_time will return 1 if there is currently a
boost, and 0 if there is not a boost. Writing 0 will cancel any current
boost, and writing a non-zero number will cancel any current boost and
begin boosting for that amount of time. Writing -1 will indefinitely
boost until another value is written.

This feature is hidden behind the CPU_FREQ_GOV_PEGASUSQ_BOOST Kconfig
flag.

Change-Id: I6e81dd3ec3af5d1408b99e136e5a63789b79dfbe