### PR TITLE
crypto: testmgr - add empty test vectors for null ciphers

### DIFF
--- a/crypto/testmgr.c
+++ b/crypto/testmgr.c
@@ -1735,6 +1735,9 @@ static const struct alg_test_desc alg_test_descs[] = {
 			}
 		}
 	}, {
+		.alg = "compress_null",
+		.test = alg_test_null,
+	}, {
 		.alg = "crc32c",
 		.test = alg_test_crc32c,
 		.fips_allowed = 1,
@@ -1814,6 +1817,9 @@ static const struct alg_test_desc alg_test_descs[] = {
 				}
 			}
 		}
+	}, {
+		.alg = "digest_null",
+		.test = alg_test_null,
 	}, {
 		.alg = "ecb(__aes-aesni)",
 		.test = alg_test_null,
@@ -1935,6 +1941,9 @@ static const struct alg_test_desc alg_test_descs[] = {
 				}
 			}
 		}
+	}, {
+		.alg = "ecb(cipher_null)",
+		.test = alg_test_null,
 	}, {
 		.alg = "ecb(des)",
 		.test = alg_test_skcipher,


### PR DESCRIPTION
Without these, kernel log shows:
[    5.984881] alg: No test for cipher_null (cipher_null-generic)
[    5.985096] alg: No test for ecb(cipher_null) (ecb-cipher_null)
[    5.985170] alg: No test for compress_null (compress_null-generic)
[    5.985297] alg: No test for digest_null (digest_null-generic)

Change-Id: I78448a5a39617212489aa14227569a2254811e14
Signed-off-by: Jussi Kivilinna <jussi.kivilinna@iki.fi>
Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>