### PR TITLE
ion: disable system contig heap

### DIFF
--- a/drivers/gpu/ion/ion_heap.c
+++ b/drivers/gpu/ion/ion_heap.c
@@ -24,8 +24,9 @@ struct ion_heap *ion_heap_create(struct ion_platform_heap *heap_data)
 
 	switch (heap_data->type) {
 	case ION_HEAP_TYPE_SYSTEM_CONTIG:
-		heap = ion_system_contig_heap_create(heap_data);
-		break;
+		pr_err("%s: Heap type is disabled: %d", __func__,
+				heap_data->type);
+		return ERR_PTR(-EINVAL);
 	case ION_HEAP_TYPE_SYSTEM:
 		heap = ion_system_heap_create(heap_data);
 		break;
@@ -57,7 +58,8 @@ void ion_heap_destroy(struct ion_heap *heap)
 
 	switch (heap->type) {
 	case ION_HEAP_TYPE_SYSTEM_CONTIG:
-		ion_system_contig_heap_destroy(heap);
+		pr_err("%s: Heap type is disabled: %d", __func__,
+				heap->type);
 		break;
 	case ION_HEAP_TYPE_SYSTEM:
 		ion_system_heap_destroy(heap);


### PR DESCRIPTION
A malicious application can take advantage of the ION contig heap to
create a specific memory chunk size to exercise a rowhammer attack on the
physical hardware.
So remove support for the ION contig heap.

Change-Id: I9cb454cebb74df291479cecc3533d2c684363f77
Signed-off-by: Liam Mark <lmark@codeaurora.org>
Signed-off-by: Prakash Gupta <guptap@codeaurora.org>